### PR TITLE
Line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 * text=auto
+# Declare files that will always have LF line endings on checkout.
+*.yml text eol=lf
+*.yaml text eol=lf

--- a/permission_data.yml
+++ b/permission_data.yml
@@ -1,19 +1,19 @@
 ---
 - hosts: all
   tasks:
-  - name: Warning!
-    debug:
-      msg: "This playbook will repermission ALL existing data in the shares defined in group_vars/all.yml to be owned by the ansible-nas user and group. If this is not what you want, exit now."
+    - name: Warning!
+      debug:
+        msg: "This playbook will repermission ALL existing data in the shares defined in group_vars/all.yml to be owned by the ansible-nas user and group. If this is not what you want, exit now."
 
-  - name: 20s to change your mind...
-    pause:
-      seconds: 20
+    - name: 20s to change your mind...
+      pause:
+        seconds: 20
 
-  - name: "Permission share data"
-    file:
-      path: "{{ item.path }}"
-      owner: ansible-nas
-      group: ansible-nas
-      mode: "u=rwX,g=rwX,o=rX"
-      recurse: true
-    loop: "{{ samba_shares }}"
+    - name: "Permission share data"
+      file:
+        path: "{{ item.path }}"
+        owner: ansible-nas
+        group: ansible-nas
+        mode: "u=rwX,g=rwX,o=rX"
+        recurse: true
+      loop: "{{ samba_shares }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

* Update all line endings to LF so that linters don't complain anymore.
* Update .gitattributes so that *.yml/*.yaml files always get LF line endings
* Fixed one linter problem in permission_data.yml


**Which issue (if any) this PR fixes**:

Fixes #

**Any other useful info**:
